### PR TITLE
Update admin password to Melatonine

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -59,7 +59,7 @@
     }
   }
 
-  var defaultAdminPasswordHash = 'e0f9e8b428dac23ec288ddfaae4dea665c3b8e38257e53d3bf94a5620273b15e';
+  var defaultAdminPasswordHash = '375fcba737931e4bdc8ddf857605426e906cb7ccf8eb4d02dadf55b891f969ad';
 
   var defaultExtraTables = {
     admin: 'planning_admin_settings',

--- a/supabase-schema.sql
+++ b/supabase-schema.sql
@@ -71,5 +71,18 @@ create index if not exists planning_choices_phase_idx on public.planning_choices
 create index if not exists planning_choices_status_idx on public.planning_choices (planning_id, status);
 create index if not exists planning_audit_log_action_idx on public.planning_audit_log (planning_id, action);
 
+-- Jeu de données par défaut pour garantir l'existence de l'identifiant "planning_gardes_state_v080".
+insert into public.planning_state (id, state)
+values ('planning_gardes_state_v080', '{}'::jsonb)
+on conflict (id)
+  do update set updated_at = timezone('utc', now());
+
+-- Mot de passe administrateur par défaut (« Melatonine ») pour l'accès aux onglets protégés.
+insert into public.planning_passwords (planning_id, name, password)
+values ('planning_gardes_state_v080', 'admin', 'Melatonine')
+on conflict (planning_id, name)
+  do update set password = excluded.password,
+                updated_at = timezone('utc', now());
+
 -- Activez Realtime sur la table principale pour bénéficier de la synchronisation instantanée :
 --   alter publication supabase_realtime add table public.planning_state;


### PR DESCRIPTION
## Summary
- update the default admin password hash so the protected sections now accept "Melatonine"
- ensure the Supabase schema script upserts the admin password entry with the new credential
- seed the planning_state table with the default planning identifier before inserting the admin password so the foreign key constraint succeeds

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e509c51828832183b2c70ca05b6d8e