### PR TITLE
Update Supabase SQL script with defaults and triggers

### DIFF
--- a/supabase-schema.sql
+++ b/supabase-schema.sql
@@ -1,10 +1,15 @@
--- Schema de référence pour l'application « Planning des gardes ».
--- Toutes les tables sont créées dans le schéma public par défaut.
+-- Schéma Supabase pour l'application « Planning des gardes ».
+-- Toutes les tables vivent dans le schéma public ; le script est idempotent
+-- afin de pouvoir être relancé en production sans effet de bord.
+
+begin;
+
+set search_path to public;
 
 create table if not exists public.planning_state (
   id text primary key,
   state jsonb not null,
-  updated_at timestamptz default timezone('utc', now())
+  updated_at timestamptz not null default timezone('utc', now())
 );
 
 create table if not exists public.planning_admin_settings (
@@ -13,20 +18,20 @@ create table if not exists public.planning_admin_settings (
   year integer,
   month integer,
   month_two integer,
-  holidays text,
+  holidays text default '',
   trade_enabled boolean default true,
   saisie_enabled boolean default true,
-  access jsonb,
-  tours jsonb,
-  columns jsonb,
-  updated_at timestamptz default timezone('utc', now())
+  access jsonb default '{}'::jsonb,
+  tours jsonb default '[]'::jsonb,
+  columns jsonb default '[]'::jsonb,
+  updated_at timestamptz not null default timezone('utc', now())
 );
 
 create table if not exists public.planning_users (
   planning_id text references public.planning_state(id) on delete cascade,
   name text not null,
-  role text not null,
-  updated_at timestamptz default timezone('utc', now()),
+  role text not null check (role in ('associe','remplacant')),
+  updated_at timestamptz not null default timezone('utc', now()),
   primary key (planning_id, name)
 );
 
@@ -34,7 +39,7 @@ create table if not exists public.planning_passwords (
   planning_id text references public.planning_state(id) on delete cascade,
   name text not null,
   password text not null,
-  updated_at timestamptz default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
   primary key (planning_id, name)
 );
 
@@ -52,7 +57,7 @@ create table if not exists public.planning_choices (
   day_label text,
   column_label text,
   hours_label text,
-  updated_at timestamptz default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
   primary key (planning_id, "user", cell_key)
 );
 
@@ -63,13 +68,93 @@ create table if not exists public.planning_audit_log (
   actor text,
   action text,
   payload jsonb,
-  updated_at timestamptz default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
   primary key (planning_id, idx)
 );
 
-create index if not exists planning_choices_phase_idx on public.planning_choices (planning_id, phase);
-create index if not exists planning_choices_status_idx on public.planning_choices (planning_id, status);
-create index if not exists planning_audit_log_action_idx on public.planning_audit_log (planning_id, action);
+-- Harmonise les valeurs par défaut si les tables existaient déjà.
+alter table if exists public.planning_state
+  alter column updated_at set default timezone('utc', now());
+
+alter table if exists public.planning_admin_settings
+  alter column holidays set default '';
+alter table if exists public.planning_admin_settings
+  alter column trade_enabled set default true;
+alter table if exists public.planning_admin_settings
+  alter column saisie_enabled set default true;
+alter table if exists public.planning_admin_settings
+  alter column access set default '{}'::jsonb;
+alter table if exists public.planning_admin_settings
+  alter column tours set default '[]'::jsonb;
+alter table if exists public.planning_admin_settings
+  alter column columns set default '[]'::jsonb;
+alter table if exists public.planning_admin_settings
+  alter column updated_at set default timezone('utc', now());
+
+alter table if exists public.planning_users
+  alter column updated_at set default timezone('utc', now());
+
+alter table if exists public.planning_passwords
+  alter column updated_at set default timezone('utc', now());
+
+alter table if exists public.planning_choices
+  alter column updated_at set default timezone('utc', now());
+
+alter table if exists public.planning_audit_log
+  alter column updated_at set default timezone('utc', now());
+
+-- Fonction et déclencheurs pour mettre à jour automatiquement le champ updated_at.
+create or replace function public.set_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = timezone('utc', now());
+  return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists trg_planning_state_updated_at on public.planning_state;
+create trigger trg_planning_state_updated_at
+  before update on public.planning_state
+  for each row execute function public.set_updated_at();
+
+drop trigger if exists trg_planning_admin_settings_updated_at on public.planning_admin_settings;
+create trigger trg_planning_admin_settings_updated_at
+  before update on public.planning_admin_settings
+  for each row execute function public.set_updated_at();
+
+drop trigger if exists trg_planning_users_updated_at on public.planning_users;
+create trigger trg_planning_users_updated_at
+  before update on public.planning_users
+  for each row execute function public.set_updated_at();
+
+drop trigger if exists trg_planning_passwords_updated_at on public.planning_passwords;
+create trigger trg_planning_passwords_updated_at
+  before update on public.planning_passwords
+  for each row execute function public.set_updated_at();
+
+drop trigger if exists trg_planning_choices_updated_at on public.planning_choices;
+create trigger trg_planning_choices_updated_at
+  before update on public.planning_choices
+  for each row execute function public.set_updated_at();
+
+drop trigger if exists trg_planning_audit_log_updated_at on public.planning_audit_log;
+create trigger trg_planning_audit_log_updated_at
+  before update on public.planning_audit_log
+  for each row execute function public.set_updated_at();
+
+-- Index utilisés par l'application pour filtrer rapidement les données dérivées.
+create index if not exists planning_choices_phase_idx
+  on public.planning_choices (planning_id, phase);
+create index if not exists planning_choices_status_idx
+  on public.planning_choices (planning_id, status);
+create index if not exists planning_choices_user_idx
+  on public.planning_choices (planning_id, "user");
+create index if not exists planning_choices_timestamp_idx
+  on public.planning_choices (planning_id, timestamp);
+create index if not exists planning_audit_log_action_idx
+  on public.planning_audit_log (planning_id, action);
+create index if not exists planning_audit_log_actor_idx
+  on public.planning_audit_log (planning_id, actor);
 
 -- Mot de passe administrateur par défaut (« Melatonine ») pour l'accès aux onglets protégés.
 insert into public.planning_passwords (planning_id, name, password)
@@ -77,6 +162,8 @@ values ('planning_gardes_state_v080', 'admin', 'Melatonine')
 on conflict (planning_id, name)
   do update set password = excluded.password,
                 updated_at = timezone('utc', now());
+
+commit;
 
 -- Activez Realtime sur la table principale pour bénéficier de la synchronisation instantanée :
 --   alter publication supabase_realtime add table public.planning_state;


### PR DESCRIPTION
## Summary
- add defaults and constraints to the Supabase schema for admin and derived tables
- install automatic updated_at triggers and helper indexes for downstream queries
- wrap the script in a transaction and harmonise defaults so it can be re-run safely

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5175182608321a02bfe8e9afa781c